### PR TITLE
chore: update lake and toolchain

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,6 +1,7 @@
 import Lake
 open Lake DSL
 
-package Cli {
-  defaultFacet := PackageFacet.oleans
-}
+package Cli
+
+@[defaultTarget]
+lean_lib Cli

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-05-21
+leanprover/lean4:nightly-2022-06-19


### PR DESCRIPTION
The lake format was changed, the old one is still supported but most likely not forever
since one of the main reasons was to allow the underlying representation to be changed if
required. So I'm updating this now to avoid issues in the future.