### PR TITLE
feat: ParseableType ModuleName supporting paths or module identifiers

### DIFF
--- a/Cli/Basic.lean
+++ b/Cli/Basic.lean
@@ -232,6 +232,17 @@ section Configuration
       | "" => none
       | s  => s.toInt?
 
+  open Lean System in
+  /-- A custom command-line argument parser that allows either relative paths to Lean files,
+  (e.g. `Mathlib/Topology/Basic.lean`) or the module name (e.g. `Mathlib.Topology.Basic`). -/
+  instance : ParseableType Name where
+    name     := "Name"
+    parse? s :=
+      if s.endsWith ".lean" then
+        some <| (s : FilePath).withExtension "" |>.components.foldl Name.mkStr Name.anonymous
+      else
+        String.toName s
+
   instance [inst : ParseableType α] : ParseableType (Array α) where
     name :=
       if inst.name.contains ' ' then

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-11-20
+leanprover/lean4:nightly-2023-08-15


### PR DESCRIPTION
We use this in Mathlib now, and might as well offer it upstream.